### PR TITLE
Add OnIndex middleware, clean-up error messages and names

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ func TestFooExplicit(t *testing.T) {
 }
 ```
 
-If we where going to do this every time, we would grow tiered. Therefore there is several short-hand methods defined on the Check and ValueFunc instances that makes things easier. The least verbose variant we can write of the test bellow, is as follows:
+If we where going to do this every time, we would grow weary. Therefore there is several short-hand methods defined on the Check and ValueFunc instances that makes things easier. The least verbose variant we can write of the test above is as follows:
 
 ```go
 func TestFoo(t *testing.T) {
@@ -142,14 +142,20 @@ It is possible to validate more than just equality with subtest. The `subtest.Sc
 
 ```go
 func TestJSONMap(t *testing.T) {
-    v := `{"foo": "bar", "baz": "foobar"}`
+    v := `{"foo": "bar", "bar": "foobar", "baz": ["foo", "bar", "baz"]}`
 
     expect := subtest.Schema{
         Fields: subtest.Fields{
             "foo": subjson.DecodesTo("bar")
-            "baz": subjson.OnLen(subtest.AllOf{
+            "bar": subjson.OnLen(subtest.AllOf{
                 subtest.GreaterThan(3),
                 subtest.LessThan(8),
+            }),
+            "baz": subjson.OnSlice(subtest.AllOf{
+                subtest.OnLen(subtest.DeepEqual(3)),
+                subtest.OnIndex(0, subjson.DecodesTo("foo"),
+                subtest.OnIndex(1, subtest.MatchPattern(`"^b??$"`), // regex match against raw JSON
+                subtest.OnIndex(2, subtest.DeepEqual(json.RawMessage(`"baz"`)), // raw JSON equals
             }),
         },
     }
@@ -226,7 +232,7 @@ Example output from an `exaples/gwt`:
     --- FAIL: TestFoo/Given_nothing_is_registered (0.00s)
         --- FAIL: TestFoo/Given_nothing_is_registered/When_calling_reg.Foo (0.00s)
             --- FAIL: TestFoo/Given_nothing_is_registered/When_calling_reg.Foo/Then_the_result_should_hold_a_zero-value (0.00s)
-                pkg_test.go:19: values are not deep equal
+                pkg_test.go:19: not deep equal
                     got: string
                         "oops"
                     want: string

--- a/check.go
+++ b/check.go
@@ -144,9 +144,9 @@ func GreaterThanOrEqual(expect float64) CheckFunc {
 	}
 }
 
-// NumericNotEqual returns a check function that fails when the test value is
+// NotNumericEqual returns a check function that fails when the test value is
 // a numeric value equal to expect.
-func NumericNotEqual(expect float64) CheckFunc {
+func NotNumericEqual(expect float64) CheckFunc {
 	return func(got interface{}) error {
 		f, ok := asFloat64(got)
 		if !ok {
@@ -230,8 +230,8 @@ func ReflectNil() CheckFunc {
 }
 
 // MatchRegexp returns a check function that fails if the test value does not
-// match r. Allowed test value types are string, []byte, json.RawMessage and
-// io.RuneReader.
+// match r. Allowed test value types are string, []byte, json.RawMessage,
+// io.RuneReader and error.
 func MatchRegexp(r *regexp.Regexp) CheckFunc {
 	return func(got interface{}) error {
 		var match bool
@@ -244,6 +244,8 @@ func MatchRegexp(r *regexp.Regexp) CheckFunc {
 			match = r.Match([]byte(gt))
 		case io.RuneReader:
 			match = r.MatchReader(gt)
+		case error:
+			match = gt != nil && r.MatchString(gt.Error())
 		default:
 			return FailGot(prefixNotRegexpType, got)
 		}
@@ -254,9 +256,8 @@ func MatchRegexp(r *regexp.Regexp) CheckFunc {
 	}
 }
 
-// MatchRegexpPattern is a short-hand for
-// MatchRegexp(regexp.MustCompile(pattern)).
-func MatchRegexpPattern(pattern string) CheckFunc {
+// MatchPattern is a short-hand for MatchRegexp(regexp.MustCompile(pattern)).
+func MatchPattern(pattern string) CheckFunc {
 	return MatchRegexp(regexp.MustCompile(pattern))
 }
 

--- a/check_middleware.go
+++ b/check_middleware.go
@@ -9,7 +9,7 @@ func OnFloat64(c Check) CheckFunc {
 }
 
 // OnLen returns a check function where the length of the test value is
-// extracted and passed to cf. Accepted input types are arrays, slices, maps,
+// extracted and passed to c. Accepted input types are arrays, slices, maps,
 // channels and strings.
 func OnLen(c Check) CheckFunc {
 	return func(got interface{}) error {
@@ -19,9 +19,9 @@ func OnLen(c Check) CheckFunc {
 }
 
 // OnCap returns a check function where the capacity of the test value is
-// extracted and passed to cf. Accepted input types are arrays, slices and
+// extracted and passed to c. Accepted input types are arrays, slices and
 // channels.
-func OnCap(cf Check) CheckFunc {
+func OnCap(c Check) CheckFunc {
 	return func(got interface{}) error {
 		vf := Cap(got)
 		return cf.Check(vf)

--- a/check_middleware.go
+++ b/check_middleware.go
@@ -1,10 +1,16 @@
 package subtest
 
+import "fmt"
+
 // OnFloat64 returns a check function where the test value is converted to
 // float64 before it's passed to c.
 func OnFloat64(c Check) CheckFunc {
 	return func(got interface{}) error {
-		return c.Check(Float64(got))
+		err := c.Check(Float64(got))
+		if err != nil {
+			return fmt.Errorf("on float64: %w", err)
+		}
+		return nil
 	}
 }
 
@@ -13,8 +19,11 @@ func OnFloat64(c Check) CheckFunc {
 // channels and strings.
 func OnLen(c Check) CheckFunc {
 	return func(got interface{}) error {
-		vf := Len(got)
-		return c.Check(vf)
+		err := c.Check(Len(got))
+		if err != nil {
+			return fmt.Errorf("on len: %w", err)
+		}
+		return nil
 	}
 }
 
@@ -23,8 +32,11 @@ func OnLen(c Check) CheckFunc {
 // channels.
 func OnCap(c Check) CheckFunc {
 	return func(got interface{}) error {
-		vf := Cap(got)
-		return cf.Check(vf)
+		err := c.Check(Cap(got))
+		if err != nil {
+			return fmt.Errorf("on cap: %w", err)
+		}
+		return nil
 	}
 }
 
@@ -33,6 +45,10 @@ func OnCap(c Check) CheckFunc {
 func OnIndex(i int, c Check) CheckFunc {
 	return func(got interface{}) error {
 		vf := Index(got, i)
-		return c.Check(vf)
+		err := c.Check(vf)
+		if err != nil {
+			return fmt.Errorf("on index %d: %w", i, err)
+		}
+		return nil
 	}
 }

--- a/check_middleware.go
+++ b/check_middleware.go
@@ -27,3 +27,12 @@ func OnCap(cf Check) CheckFunc {
 		return cf.Check(vf)
 	}
 }
+
+// OnIndex returns a check function where the item at index i of the test value
+// is passed on to c. Accepted input types are arrays, slices and strings.
+func OnIndex(i int, c Check) CheckFunc {
+	return func(got interface{}) error {
+		vf := Index(got, i)
+		return c.Check(vf)
+	}
+}

--- a/check_middleware_test.go
+++ b/check_middleware_test.go
@@ -28,7 +28,7 @@ func TestOnFloat64(t *testing.T) {
 		})
 		t.Run(`when cheking against string("invalid")`, func(t *testing.T) {
 			vf := subtest.Value(cf("invalid"))
-			expect := subtest.FailGot("value not convertable to float64", "invalid")
+			expect := subtest.FailGot("not convertable to float64", "invalid")
 			t.Run("then it should fail", vf.ErrorIs(expect))
 		})
 	})
@@ -48,7 +48,7 @@ func TestOnLen(t *testing.T) {
 		})
 		t.Run(`when cheking against string("42")`, func(t *testing.T) {
 			vf := subtest.Value(cf("42"))
-			expect := subtest.FailExpect("values are not deep equal", 2, 3)
+			expect := subtest.FailExpect("not deep equal", 2, 3)
 			t.Run("then it should fail", vf.ErrorIs(expect))
 		})
 	})
@@ -63,7 +63,7 @@ func TestOnCap(t *testing.T) {
 		})
 		t.Run("when cheking against make([]int,3,4)", func(t *testing.T) {
 			vf := subtest.Value(cf(make([]int, 3, 4)))
-			expect := subtest.FailExpect("values are not deep equal", 4, 3)
+			expect := subtest.FailExpect("not deep equal", 4, 3)
 			t.Run("then it should pass", vf.ErrorIs(expect))
 		})
 		t.Run(`when cheking against int64(42)`, func(t *testing.T) {

--- a/check_test.go
+++ b/check_test.go
@@ -18,7 +18,7 @@ func TestDeepEqual(t *testing.T) {
 		t.Run("when cheking against false", func(t *testing.T) {
 			vf := subtest.Value(cf(false))
 			t.Run("then an appropriate error should be returned", vf.ErrorIs(subtest.Failure{
-				Prefix: "values are not deep equal",
+				Prefix: "not deep equal",
 				Got:    "bool\n\tfalse",
 				Expect: "bool\n\ttrue",
 			}))
@@ -65,7 +65,7 @@ func TestNotDeepEqual(t *testing.T) {
 		t.Run("when cheking against false", func(t *testing.T) {
 			vf := subtest.Value(cf(false))
 			t.Run("then an appropriate error should be returned", vf.ErrorIs(subtest.Failure{
-				Prefix: "values are deep equal",
+				Prefix: "deep equal",
 				Got:    "bool\n\tfalse",
 				Reject: "bool\n\tfalse",
 			}))
@@ -119,7 +119,7 @@ func TestCheckReflectNil(t *testing.T) {
 	t.Run("when cheking against a non-nil struct pointer", func(t *testing.T) {
 		vf := subtest.Value(cf(&T{}))
 		t.Run("then an appropriate error should be returned", vf.ErrorIs(subtest.Failure{
-			Prefix: "value is neither typed nor untyped nil",
+			Prefix: "neither typed nor untyped nil",
 			Got:    "*subtest_test.T\n\t{Foo:}",
 		}))
 	})
@@ -134,14 +134,14 @@ func TestCheckNotReflectNil(t *testing.T) {
 	t.Run("when cheking against untyped nil", func(t *testing.T) {
 		vf := subtest.Value(cf(nil))
 		t.Run("then an appropriate error should be returned", vf.ErrorIs(subtest.Failure{
-			Prefix: "value is typed or untyped nil",
+			Prefix: "typed or untyped nil",
 			Got:    "untyped nil",
 		}))
 	})
 	t.Run("when cheking against a nil struct pointer", func(t *testing.T) {
 		vf := subtest.Value(cf((*T)(nil)))
 		t.Run("then an appropriate error should be returned", vf.ErrorIs(subtest.Failure{
-			Prefix: "value is typed or untyped nil",
+			Prefix: "typed or untyped nil",
 			Got:    "*subtest_test.T\n\tnil",
 		}))
 	})
@@ -165,7 +165,7 @@ func TestLessThan(t *testing.T) {
 			cf := subtest.LessThan(42)
 			vf := subtest.Value(cf(v))
 			expect := subtest.Failure{
-				Prefix: "not < 42.000000",
+				Prefix: "not less than 42.000000",
 				Got:    "float64\n\t42",
 			}
 			t.Run("then it should fail", vf.ErrorIs(expect))
@@ -182,7 +182,7 @@ func TestLessThan(t *testing.T) {
 			cf := subtest.LessThan(42)
 			vf := subtest.Value(cf(v))
 			expect := subtest.Failure{
-				Prefix: "not < 42.000000",
+				Prefix: "not less than 42.000000",
 				Got:    "int16\n\t42",
 			}
 			t.Run("then it should fail", vf.ErrorIs(expect))
@@ -207,7 +207,7 @@ func TestLessThanOrEqual(t *testing.T) {
 			cf := subtest.LessThanOrEqual(41)
 			vf := subtest.Value(cf(v))
 			expect := subtest.Failure{
-				Prefix: "not <= 41.000000",
+				Prefix: "not less than or equal to 41.000000",
 				Got:    "float64\n\t42",
 			}
 			t.Run("then it should fail", vf.ErrorIs(expect))
@@ -224,7 +224,7 @@ func TestLessThanOrEqual(t *testing.T) {
 			cf := subtest.LessThanOrEqual(41)
 			vf := subtest.Value(cf(v))
 			expect := subtest.Failure{
-				Prefix: "not <= 41.000000",
+				Prefix: "not less than or equal to 41.000000",
 				Got:    "int16\n\t42",
 			}
 			t.Run("then it should fail", vf.ErrorIs(expect))
@@ -244,7 +244,7 @@ func TestGreaterThan(t *testing.T) {
 			cf := subtest.GreaterThan(42)
 			vf := subtest.Value(cf(v))
 			expect := subtest.Failure{
-				Prefix: "not > 42.000000",
+				Prefix: "not greater than 42.000000",
 				Got:    "float64\n\t42",
 			}
 			t.Run("then it should fail", vf.ErrorIs(expect))
@@ -261,7 +261,7 @@ func TestGreaterThan(t *testing.T) {
 			cf := subtest.GreaterThan(42)
 			vf := subtest.Value(cf(v))
 			expect := subtest.Failure{
-				Prefix: "not > 42.000000",
+				Prefix: "not greater than 42.000000",
 				Got:    "int16\n\t42",
 			}
 			t.Run("then it should fail", vf.ErrorIs(expect))
@@ -286,7 +286,7 @@ func TestGreaterThanOrEqual(t *testing.T) {
 			cf := subtest.GreaterThanOrEqual(43)
 			vf := subtest.Value(cf(v))
 			expect := subtest.Failure{
-				Prefix: "not >= 43.000000",
+				Prefix: "not greater than or equal to 43.000000",
 				Got:    "float64\n\t42",
 			}
 			t.Run("then it should fail", vf.ErrorIs(expect))
@@ -303,7 +303,7 @@ func TestGreaterThanOrEqual(t *testing.T) {
 			cf := subtest.GreaterThanOrEqual(43)
 			vf := subtest.Value(cf(v))
 			expect := subtest.Failure{
-				Prefix: "not >= 43.000000",
+				Prefix: "not greater than or equal to 43.000000",
 				Got:    "int16\n\t42",
 			}
 			t.Run("then it should fail", vf.ErrorIs(expect))
@@ -318,8 +318,9 @@ func TestNumericEqual(t *testing.T) {
 			cf := subtest.NumericEqual(41)
 			vf := subtest.Value(cf(v))
 			expect := subtest.Failure{
-				Prefix: "not == 41.000000",
+				Prefix: "not numeric equal",
 				Got:    "float64\n\t42",
+				Expect: "float64\n\t41",
 			}
 			t.Run("then it should fail", vf.ErrorIs(expect))
 		})
@@ -332,39 +333,37 @@ func TestNumericEqual(t *testing.T) {
 			cf := subtest.NumericEqual(43)
 			vf := subtest.Value(cf(v))
 			expect := subtest.Failure{
-				Prefix: "not == 43.000000",
+				Prefix: "not numeric equal",
 				Got:    "float64\n\t42",
+				Expect: "float64\n\t43",
 			}
 			t.Run("then it should fail", vf.ErrorIs(expect))
 		})
 	})
 }
 
-func TestNumericNotEqual(t *testing.T) {
+func TestNotNumericEqual(t *testing.T) {
 	t.Run("given a value float64(42)", func(t *testing.T) {
 		v := float64(42)
 		t.Run("when cheking against 41", func(t *testing.T) {
-			cf := subtest.NumericEqual(41)
-			vf := subtest.Value(cf(v))
-			expect := subtest.Failure{
-				Prefix: "not == 41.000000",
-				Got:    "float64\n\t42",
-			}
-			t.Run("then it should fail", vf.ErrorIs(expect))
-		})
-		t.Run("when cheking against 42", func(t *testing.T) {
-			cf := subtest.NumericEqual(42)
+			cf := subtest.NotNumericEqual(41)
 			vf := subtest.Value(cf(v))
 			t.Run("then it should not fail", vf.NoError())
 		})
-		t.Run("when cheking against 43", func(t *testing.T) {
-			cf := subtest.NumericEqual(43)
+		t.Run("when cheking against 42", func(t *testing.T) {
+			cf := subtest.NotNumericEqual(42)
 			vf := subtest.Value(cf(v))
 			expect := subtest.Failure{
-				Prefix: "not == 43.000000",
+				Prefix: "numeric equal",
 				Got:    "float64\n\t42",
+				Reject: "float64\n\t42",
 			}
 			t.Run("then it should fail", vf.ErrorIs(expect))
+		})
+		t.Run("when cheking against 43", func(t *testing.T) {
+			cf := subtest.NotNumericEqual(43)
+			vf := subtest.Value(cf(v))
+			t.Run("then it should not fail", vf.NoError())
 		})
 	})
 	t.Run("given a value int16(42)", func(t *testing.T) {
@@ -373,8 +372,9 @@ func TestNumericNotEqual(t *testing.T) {
 			cf := subtest.NotNumericEqual(42)
 			vf := subtest.Value(cf(v))
 			expect := subtest.Failure{
-				Prefix: "not >= 43.000000",
+				Prefix: "numeric equal",
 				Got:    "int16\n\t42",
+				Reject: "float64\n\t42",
 			}
 			t.Run("then it should fail", vf.ErrorIs(expect))
 		})

--- a/check_test.go
+++ b/check_test.go
@@ -370,18 +370,18 @@ func TestNumericNotEqual(t *testing.T) {
 	t.Run("given a value int16(42)", func(t *testing.T) {
 		v := int16(42)
 		t.Run("when cheking against 42", func(t *testing.T) {
-			cf := subtest.GreaterThanOrEqual(42)
-			vf := subtest.Value(cf(v))
-			t.Run("then it should not fail", vf.NoError())
-		})
-		t.Run("when cheking against 43", func(t *testing.T) {
-			cf := subtest.GreaterThanOrEqual(43)
+			cf := subtest.NotNumericEqual(42)
 			vf := subtest.Value(cf(v))
 			expect := subtest.Failure{
 				Prefix: "not >= 43.000000",
 				Got:    "int16\n\t42",
 			}
 			t.Run("then it should fail", vf.ErrorIs(expect))
+		})
+		t.Run("when cheking against 43", func(t *testing.T) {
+			cf := subtest.NotNumericEqual(43)
+			vf := subtest.Value(cf(v))
+			t.Run("then it should not fail", vf.NoError())
 		})
 	})
 }

--- a/error.go
+++ b/error.go
@@ -8,9 +8,11 @@ import (
 )
 
 const (
-	msgNoLen     = "type does not support len"
-	msgNoCap     = "type does not support cap"
-	msgNoFloat64 = "value not convertable to float64"
+	msgNoLen           = "type does not support len"
+	msgNoCap           = "type does not support cap"
+	msgNoIndex         = "type does not support index operation"
+	msgIndexOutOfRange = "index out of range"
+	msgNoFloat64       = "value not convertable to float64"
 )
 
 // Failure is an error type that aid with consistent formatting of test

--- a/schema.go
+++ b/schema.go
@@ -125,11 +125,7 @@ func (s Schema) checkMap(got interface{}) error {
 	}
 
 	if len(errs) > 0 {
-		return PrefixError{
-			Key:     "value not matching schema",
-			Err:     errs,
-			Newline: true,
-		}
+		return fmt.Errorf("%s: %w", msgSchemaMatch, errs)
 	}
 	return nil
 }

--- a/subjson/check_middleware.go
+++ b/subjson/check_middleware.go
@@ -1,6 +1,8 @@
 package subjson
 
 import (
+	"fmt"
+
 	"github.com/searis/subtest"
 )
 
@@ -8,7 +10,11 @@ import (
 // string.
 func OnString(c subtest.Check) subtest.CheckFunc {
 	return func(got interface{}) error {
-		return c.Check(String(got))
+		err := c.Check(String(got))
+		if err != nil {
+			return fmt.Errorf("on JSON decoded string: %w", err)
+		}
+		return nil
 	}
 }
 
@@ -16,7 +22,11 @@ func OnString(c subtest.Check) subtest.CheckFunc {
 // json.Number before it's passed to cf.
 func OnNumber(c subtest.Check) subtest.CheckFunc {
 	return func(got interface{}) error {
-		return c.Check(Number(got))
+		err := c.Check(Number(got))
+		if err != nil {
+			return fmt.Errorf("on JSON decoded number: %w", err)
+		}
+		return nil
 	}
 }
 
@@ -24,7 +34,11 @@ func OnNumber(c subtest.Check) subtest.CheckFunc {
 // int64 before it's passed to cf.
 func OnInt64(c subtest.Check) subtest.CheckFunc {
 	return func(got interface{}) error {
-		return c.Check(Int64(got))
+		err := c.Check(Int64(got))
+		if err != nil {
+			return fmt.Errorf("on JSON decoded int64: %w", err)
+		}
+		return nil
 	}
 }
 
@@ -32,7 +46,11 @@ func OnInt64(c subtest.Check) subtest.CheckFunc {
 // float64 before it's passed to cf.
 func OnFloat64(c subtest.Check) subtest.CheckFunc {
 	return func(got interface{}) error {
-		return c.Check(Float64(got))
+		err := c.Check(Float64(got))
+		if err != nil {
+			return fmt.Errorf("on JSON decoded float64: %w", err)
+		}
+		return nil
 	}
 }
 
@@ -40,7 +58,11 @@ func OnFloat64(c subtest.Check) subtest.CheckFunc {
 // []json.RawMessage before it's passed to cf.
 func OnSlice(c subtest.Check) subtest.CheckFunc {
 	return func(got interface{}) error {
-		return c.Check(Slice(got))
+		err := c.Check(Slice(got))
+		if err != nil {
+			return fmt.Errorf("on JSON decoded slice: %w", err)
+		}
+		return nil
 	}
 }
 
@@ -48,7 +70,11 @@ func OnSlice(c subtest.Check) subtest.CheckFunc {
 // map[string]json.RawMessage before it's passed to cf.
 func OnMap(c subtest.Check) subtest.CheckFunc {
 	return func(got interface{}) error {
-		return c.Check(Map(got))
+		err := c.Check(Map(got))
+		if err != nil {
+			return fmt.Errorf("on JSON decoded map: %w", err)
+		}
+		return nil
 	}
 }
 
@@ -56,6 +82,10 @@ func OnMap(c subtest.Check) subtest.CheckFunc {
 // interface{} value.
 func OnInterface(c subtest.Check) subtest.CheckFunc {
 	return func(got interface{}) error {
-		return c.Check(Interface(got))
+		err := c.Check(Interface(got))
+		if err != nil {
+			return fmt.Errorf("on JSON decoded value: %w", err)
+		}
+		return nil
 	}
 }

--- a/subjson/example_onmap_test.go
+++ b/subjson/example_onmap_test.go
@@ -7,6 +7,26 @@ import (
 	"github.com/searis/subtest/subjson"
 )
 
+func ExampleMap_failingTest() {
+	const v = `{"foo":"bar", "bar":"baz"}`
+
+	t.Run("v match cf", subjson.Map(v).DeepEqual(map[string]json.RawMessage{
+		"foo": json.RawMessage(`"bar"`),
+		"bar": json.RawMessage(`"foobar"`),
+	}))
+	// FIXME: t.Helper issue causes return of value.go:130 instead of this file.
+	// Could be related to https://github.com/golang/go/issues/23249.
+
+	// Output:
+	// === RUN   ParentTest/v_match_cf
+	// --- FAIL: ParentTest/v_match_cf (0.00s)
+	//     value.go:130: not deep equal
+	//         got: map[string]json.RawMessage
+	//             map[bar:[34 98 97 122 34] foo:[34 98 97 114 34]]
+	//         want: map[string]json.RawMessage
+	//             map[bar:[34 102 111 111 98 97 114 34] foo:[34 98 97 114 34]]
+}
+
 func ExampleOnMap_failingTest() {
 	const v = `{"foo":"bar", "bar":"baz"}`
 	cf := subtest.DeepEqual(map[string]json.RawMessage{
@@ -17,19 +37,43 @@ func ExampleOnMap_failingTest() {
 	t.Run("v match cf", subtest.Value(v).Test(
 		subjson.OnMap(cf),
 	))
-	// FIXME: t.Helper issue causes return of value.go:112 instead of this file.
+	// FIXME: t.Helper issue causes return of value.go:130 instead of this file.
 	// Could be related to https://github.com/golang/go/issues/23249.
 
 	// Output:
 	// === RUN   ParentTest/v_match_cf
 	// --- FAIL: ParentTest/v_match_cf (0.00s)
-	//     value.go:112: values are not deep equal
+	//     value.go:130: on JSON decoded map: not deep equal
 	//         got: map[string]json.RawMessage
 	//             map[bar:[34 98 97 122 34] foo:[34 98 97 114 34]]
 	//         want: map[string]json.RawMessage
 	//             map[bar:[34 102 111 111 98 97 114 34] foo:[34 98 97 114 34]]
 }
 
+func ExampleMap_failingSchemaTest() {
+	const v = `{"foo":"bar", "bar":"baz"}`
+	c := subtest.Schema{
+		Fields: subtest.Fields{
+			"foo": subjson.DecodesTo("bar"),                       // check decoded content.
+			"bar": subtest.DeepEqual(json.RawMessage(`"foobar"`)), // check raw JSON.
+		},
+	}
+
+	t.Run("v match cf", subjson.Map(v).Test(c))
+	// FIXME: t.Helper issue causes return of value.go:130 instead of this file.
+	// Could be related to https://github.com/golang/go/issues/23249.
+
+	// Output:
+	// === RUN   ParentTest/v_match_cf
+	// --- FAIL: ParentTest/v_match_cf (0.00s)
+	//     value.go:130: not matching schema: 1 issue(s)
+	//         issue #0:
+	//             key "bar": not deep equal
+	//             got: json.RawMessage
+	//                 `"baz"`
+	//             want: json.RawMessage
+	//                 `"foobar"`
+}
 func ExampleOnMap_failingSchemaTest() {
 	const v = `{"foo":"bar", "bar":"baz"}`
 	c := subtest.Schema{
@@ -40,18 +84,31 @@ func ExampleOnMap_failingSchemaTest() {
 	}
 
 	t.Run("v match cf", subtest.Value(v).Test(subjson.OnMap(c)))
-	// FIXME: t.Helper issue causes return of value.go:112 instead of this file.
+	// FIXME: t.Helper issue causes return of value.go:130 instead of this file.
 	// Could be related to https://github.com/golang/go/issues/23249.
 
 	// Output:
 	// === RUN   ParentTest/v_match_cf
 	// --- FAIL: ParentTest/v_match_cf (0.00s)
-	//     value.go:112: value not matching schema:
-	//         #0: key "bar": values are not deep equal
-	//         got: json.RawMessage
-	//             `"baz"`
-	//         want: json.RawMessage
-	//             `"foobar"`
+	//     value.go:130: on JSON decoded map: not matching schema: 1 issue(s)
+	//         issue #0:
+	//             key "bar": not deep equal
+	//             got: json.RawMessage
+	//                 `"baz"`
+	//             want: json.RawMessage
+	//                 `"foobar"`
+}
+
+func ExampleMap_passingTest() {
+	const v = `{"foo":"bar", "bar":"baz"}`
+
+	t.Run("v match cf", subjson.Map(v).DeepEqual(map[string]json.RawMessage{
+		"foo": json.RawMessage(`"bar"`),
+		"bar": json.RawMessage(`"baz"`),
+	}))
+	// Output:
+	// === RUN   ParentTest/v_match_cf
+	// --- PASS: ParentTest/v_match_cf (0.00s)
 }
 func ExampleOnMap_passingTest() {
 	const v = `{"foo":"bar", "bar":"baz"}`

--- a/value.go
+++ b/value.go
@@ -33,7 +33,7 @@ func Len(v interface{}) ValueFunc {
 	return func() (interface{}, error) {
 		l, ok := asLen(v)
 		if !ok {
-			return nil, FailGot(msgNoLen, v)
+			return nil, FailGot(msgNotLenType, v)
 		}
 		return l, nil
 	}
@@ -54,7 +54,7 @@ func Cap(v interface{}) ValueFunc {
 	return func() (interface{}, error) {
 		l, ok := asCap(v)
 		if !ok {
-			return nil, FailGot(msgNoCap, v)
+			return nil, FailGot(msgNotCapType, v)
 		}
 		return l, nil
 	}
@@ -82,7 +82,7 @@ func Index(v interface{}, i int) ValueFunc {
 			}
 			return rv.Index(i).Interface(), nil
 		default:
-			return nil, FailGot(msgNoIndex, v)
+			return nil, FailGot(msgNotIndexType, v)
 		}
 	}
 }
@@ -93,7 +93,7 @@ func Float64(v interface{}) ValueFunc {
 	return func() (interface{}, error) {
 		f, ok := asFloat64(v)
 		if !ok {
-			return nil, FailGot(msgNoFloat64, v)
+			return nil, FailGot(msgNotFloat64, v)
 		}
 		return f, nil
 	}

--- a/value.go
+++ b/value.go
@@ -152,9 +152,9 @@ func (vf ValueFunc) GreaterThanOrEqual(v float64) func(t *testing.T) {
 	return vf.Test(GreaterThanOrEqual(v))
 }
 
-// NumericNotEqual is equivalent to vf.Test(NumericNotEqual(v)).
-func (vf ValueFunc) NumericNotEqual(v float64) func(t *testing.T) {
-	return vf.Test(NumericNotEqual(v))
+// NotNumericEqual is equivalent to vf.Test(NotNumericEqual(v)).
+func (vf ValueFunc) NotNumericEqual(v float64) func(t *testing.T) {
+	return vf.Test(NotNumericEqual(v))
 }
 
 // NumericEqual is equivalent to vf.Test(NumericEqual(v)).
@@ -187,9 +187,9 @@ func (vf ValueFunc) MatchRegexp(r *regexp.Regexp) func(t *testing.T) {
 	return vf.Test(MatchRegexp(r))
 }
 
-// MatchRegexpPattern is equivalent to vf.Test(s.MatchRegexpPattern(pattern)).
-func (vf ValueFunc) MatchRegexpPattern(pattern string) func(t *testing.T) {
-	return vf.Test(MatchRegexpPattern(pattern))
+// MatchPattern is equivalent to vf.Test(s.MatchPattern(pattern)).
+func (vf ValueFunc) MatchPattern(pattern string) func(t *testing.T) {
+	return vf.Test(MatchPattern(pattern))
 }
 
 // NoError is equivalent to vf.Test(NoError(v)).

--- a/value.go
+++ b/value.go
@@ -1,6 +1,7 @@
 package subtest
 
 import (
+	"errors"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -69,8 +70,25 @@ func asCap(v interface{}) (c int, ok bool) {
 	return
 }
 
-// Float64 returns a new ValueFunc that parses v into a float64. Valid input
-// types are any numeric kinds  or string kinds.
+// Index returns a new ValueFunc for the value at index v[i]. Accepts input of
+// type array, slice and string.
+func Index(v interface{}, i int) ValueFunc {
+	return func() (interface{}, error) {
+		rv := reflect.ValueOf(v)
+		switch rv.Kind() {
+		case reflect.Array, reflect.Slice, reflect.String:
+			if rv.Len() <= i {
+				return nil, errors.New(msgIndexOutOfRange)
+			}
+			return rv.Index(i).Interface(), nil
+		default:
+			return nil, FailGot(msgNoIndex, v)
+		}
+	}
+}
+
+// Float64 returns a new ValueFunc that parses v into a float64. Accepts numeric
+// kinds and string kinds as input.
 func Float64(v interface{}) ValueFunc {
 	return func() (interface{}, error) {
 		f, ok := asFloat64(v)

--- a/value_test.go
+++ b/value_test.go
@@ -28,7 +28,7 @@ func TestFloat64(t *testing.T) {
 		json.Number("42"),
 	}
 	for _, v := range validInputs {
-		name := fmt.Sprintf("When calling asFloat64 on %T", v)
+		name := fmt.Sprintf("When resolving Float64 from %T", v)
 		t.Run(name, func(t *testing.T) {
 			vf := subtest.Float64(v)
 			t.Run("Then we should get the correct float64 value", vf.DeepEqual(float64(42)))

--- a/value_test.go
+++ b/value_test.go
@@ -14,7 +14,7 @@ func TestFloat64(t *testing.T) {
 		v, err := vf()
 		t.Run("Then the value should be nil", subtest.Value(v).DeepEqual(nil))
 		t.Run("Then we should get the correct error", subtest.Value(err).ErrorIs(
-			subtest.FailGot("value not convertable to float64", string("invalid")),
+			subtest.FailGot("not convertable to float64", string("invalid")),
 		))
 	})
 

--- a/value_test.go
+++ b/value_test.go
@@ -36,3 +36,42 @@ func TestFloat64(t *testing.T) {
 		})
 	}
 }
+
+func TestIndex(t *testing.T) {
+	t.Run("When resolving Index from an incompatible type", func(t *testing.T) {
+		vf := subtest.Index(map[int]string{0: "1"}, 0)
+		v, err := vf()
+		t.Run("Then it should fail with type does not support index operation",
+			subtest.Value(err).MatchPattern("^type does not support index operation"),
+		)
+		t.Run("Then the value should be nil", subtest.Value(v).DeepEqual(nil))
+	})
+	t.Run("When resolving Index 0 from empty slice", func(t *testing.T) {
+		vf := subtest.Index([]string{}, 0)
+		v, err := vf()
+		t.Run("Then it should fail with index out of range",
+			subtest.Value(err).MatchPattern("^index out of range$"),
+		)
+		t.Run("Then the value should be nil", subtest.Value(v).DeepEqual(nil))
+	})
+
+	type testData struct {
+		in    interface{}
+		index int
+		out   interface{}
+	}
+	var validInputs = []testData{
+		{in: []int{42}, index: 0, out: 42},
+		{in: []float64{42.0, 32.5}, index: 1, out: 32.5},
+		{in: "42", index: 0, out: uint8('4')},
+		{in: "42", index: 1, out: uint8('2')},
+		{in: []interface{}{nil}},
+	}
+	for _, td := range validInputs {
+		name := fmt.Sprintf("When resolving Index 0 from %#v", td.in)
+		t.Run(name, func(t *testing.T) {
+			vf := subtest.Index(td.in, td.index)
+			t.Run("Then we should get the expected value", vf.DeepEqual(td.out))
+		})
+	}
+}


### PR DESCRIPTION
commit 1b5be480ef4725b19e5691861f8937082303f8da (HEAD -> expanse2, origin/expanse2)
Author: Sindre Myren <sindre@searis.no>
Date:   Tue Feb 25 00:43:16 2020 +0100

    Improve error formatting

    Perform an overhaul of error messages to improve consistency, clarity
    and overall appearance.

    Numeric check failure messages where inconsistent with other messages and
    have been made longer. Other check error messages have been shortened.
    More specifically, the "value is" and "values are" prefixes in error
    messages have been dropped.

    We now add error prefixes for all check middle-ware. This ads necessary
    context for better understanding the check failure. E.g. "on index 1:
    not matching schema" instead of just "value not matching schema".

    Improve formatting and indentation usage for the multi-error type
    Errors.

    Update README.

commit b42eed09ee4a904f1151e6230dbdd1b41a7b2fa5
Author: Sindre Myren <sindre@searis.no>
Date:   Tue Feb 25 00:34:21 2020 +0100

    Cleanup check names, allow error regexp matching

    - Rename NumericNotEqual -> NotNumericEqual
    - Rename MatchRegexpPattern -> MatchPattern
    - Allow the MatchRegexp check function to accept error values

commit 4442d57492e95956a4fa8f398d68d42a716a1bb8
Author: Sindre Myren <sindre@searis.no>
Date:   Tue Feb 25 00:35:51 2020 +0100

    Add Index value func and OnIndex check middleware

    The new Index and OnIndex functions allows testing the value at a
    particular index of an array, slice or string value.
