### PR TITLE
Back2thefuture

### DIFF
--- a/error.go
+++ b/error.go
@@ -13,6 +13,7 @@ const (
 	msgNotIndexType    = "type does not support index operation"
 	msgNotErrorType    = "type is not error"
 	msgNotSliceArrType = "type is not slice or array"
+	msgNotTimeType     = "type is not time.Time or *time.Time"
 	msgNotFloat64      = "not convertable to float64"
 
 	msgIndexOutOfRange = "index out of range"
@@ -23,6 +24,11 @@ const (
 	msgGreaterThanOrEqual = "not greater than or equal to"
 	msgNotNumericEqual    = "numeric equal"
 	msgNumericEqual       = "not numeric equal"
+
+	msgBefore       = "time not before"
+	msgNotBefore    = "time before"
+	msgTimeEqual    = "times not equal"
+	msgNotTimeEqual = "times equal"
 
 	msgNotDeepEqual = "deep equal"
 	msgDeepEqual    = "not deep equal"
@@ -35,11 +41,10 @@ const (
 
 	msgContainsMatch = "does not match any elements"
 
-	msgNotErrorType = "type is not error"
-	msgNoError      = "error is not nil"
-	msgError        = "error is nil"
-	msgErrorIsNot   = "error is matching target error"
-	msgErrorIs      = "error is not matching target error"
+	msgNoError    = "error is not nil"
+	msgError      = "error is nil"
+	msgErrorIsNot = "error is matching target error"
+	msgErrorIs    = "error is not matching target error"
 
 	msgSchemaMatch = "not matching schema"
 )

--- a/error.go
+++ b/error.go
@@ -11,8 +11,9 @@ const (
 	msgNotLenType      = "type does not support len"
 	msgNotCapType      = "type does not support cap"
 	msgNotIndexType    = "type does not support index operation"
-	msgNotFloat64      = "not convertable to float64"
+	msgNotErrorType    = "type is not error"
 	msgNotSliceArrType = "type is not slice or array"
+	msgNotFloat64      = "not convertable to float64"
 
 	msgIndexOutOfRange = "index out of range"
 

--- a/schema_test.go
+++ b/schema_test.go
@@ -37,10 +37,10 @@ func TestSchema_map(t *testing.T) {
 			subtest.Value(map[int]string{1: "", 2: "", 3: ""}).Test(c),
 		)
 		t.Run("then it should match a map[int]struct{} value with all keys",
-			subtest.Value(map[int]struct{}{1: struct{}{}, 2: struct{}{}, 3: struct{}{}}).Test(c),
+			subtest.Value(map[int]struct{}{1: {}, 2: {}, 3: {}}).Test(c),
 		)
 		t.Run("then it should match a map[interface{}]struct{} value with all keys",
-			subtest.Value(map[interface{}]struct{}{1: struct{}{}, 2: struct{}{}, 3: struct{}{}}).Test(c),
+			subtest.Value(map[interface{}]struct{}{1: {}, 2: {}, 3: {}}).Test(c),
 		)
 		t.Run("then it should match a map with additional fields",
 			subtest.Value(map[int]string{1: "", 2: "", 3: "", 4: ""}).Test(c),

--- a/subjson/check_middleware.go
+++ b/subjson/check_middleware.go
@@ -78,6 +78,18 @@ func OnMap(c subtest.Check) subtest.CheckFunc {
 	}
 }
 
+// OnTime returns a check function where the test value is decoded into a
+// time.Time value.
+func OnTime(c subtest.Check) subtest.CheckFunc {
+	return func(got interface{}) error {
+		err := c.Check(Time(got))
+		if err != nil {
+			return fmt.Errorf("on JSON decoded time: %w", err)
+		}
+		return nil
+	}
+}
+
 // OnInterface returns a check function where the test value is decoded into a
 // interface{} value.
 func OnInterface(c subtest.Check) subtest.CheckFunc {

--- a/subjson/example_onmap_test.go
+++ b/subjson/example_onmap_test.go
@@ -14,13 +14,13 @@ func ExampleMap_failingTest() {
 		"foo": json.RawMessage(`"bar"`),
 		"bar": json.RawMessage(`"foobar"`),
 	}))
-	// FIXME: t.Helper issue causes return of value.go:130 instead of this file.
+	// FIXME: t.Helper issue causes return of value.go:131 instead of this file.
 	// Could be related to https://github.com/golang/go/issues/23249.
 
 	// Output:
 	// === RUN   ParentTest/v_match_cf
 	// --- FAIL: ParentTest/v_match_cf (0.00s)
-	//     value.go:130: not deep equal
+	//     value.go:131: not deep equal
 	//         got: map[string]json.RawMessage
 	//             map[bar:[34 98 97 122 34] foo:[34 98 97 114 34]]
 	//         want: map[string]json.RawMessage
@@ -37,13 +37,13 @@ func ExampleOnMap_failingTest() {
 	t.Run("v match cf", subtest.Value(v).Test(
 		subjson.OnMap(cf),
 	))
-	// FIXME: t.Helper issue causes return of value.go:130 instead of this file.
+	// FIXME: t.Helper issue causes return of value.go:131 instead of this file.
 	// Could be related to https://github.com/golang/go/issues/23249.
 
 	// Output:
 	// === RUN   ParentTest/v_match_cf
 	// --- FAIL: ParentTest/v_match_cf (0.00s)
-	//     value.go:130: on JSON decoded map: not deep equal
+	//     value.go:131: on JSON decoded map: not deep equal
 	//         got: map[string]json.RawMessage
 	//             map[bar:[34 98 97 122 34] foo:[34 98 97 114 34]]
 	//         want: map[string]json.RawMessage
@@ -60,13 +60,13 @@ func ExampleMap_failingSchemaTest() {
 	}
 
 	t.Run("v match cf", subjson.Map(v).Test(c))
-	// FIXME: t.Helper issue causes return of value.go:130 instead of this file.
+	// FIXME: t.Helper issue causes return of value.go:131 instead of this file.
 	// Could be related to https://github.com/golang/go/issues/23249.
 
 	// Output:
 	// === RUN   ParentTest/v_match_cf
 	// --- FAIL: ParentTest/v_match_cf (0.00s)
-	//     value.go:130: not matching schema: 1 issue(s)
+	//     value.go:131: not matching schema: 1 issue(s)
 	//         issue #0:
 	//             key "bar": not deep equal
 	//             got: json.RawMessage
@@ -84,13 +84,13 @@ func ExampleOnMap_failingSchemaTest() {
 	}
 
 	t.Run("v match cf", subtest.Value(v).Test(subjson.OnMap(c)))
-	// FIXME: t.Helper issue causes return of value.go:130 instead of this file.
+	// FIXME: t.Helper issue causes return of value.go:131 instead of this file.
 	// Could be related to https://github.com/golang/go/issues/23249.
 
 	// Output:
 	// === RUN   ParentTest/v_match_cf
 	// --- FAIL: ParentTest/v_match_cf (0.00s)
-	//     value.go:130: on JSON decoded map: not matching schema: 1 issue(s)
+	//     value.go:131: on JSON decoded map: not matching schema: 1 issue(s)
 	//         issue #0:
 	//             key "bar": not deep equal
 	//             got: json.RawMessage

--- a/subjson/example_test.go
+++ b/subjson/example_test.go
@@ -3,6 +3,7 @@ package subjson_test
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/searis/subtest"
 	"github.com/searis/subtest/internal/testmock"
@@ -37,6 +38,27 @@ func ExampleOnString() {
 
 	t.Run("v match cf", subtest.Value(v).Test(
 		subjson.OnString(cf),
+	))
+	// Output:
+	// === RUN   ParentTest/v_match_cf
+	// --- PASS: ParentTest/v_match_cf (0.00s)
+}
+
+func ExampleTime() {
+	const v = `"1985-12-19T18:15:00.0+01:00"`
+	expect := time.Date(1985, 12, 19, 17, 15, 0, 0, time.UTC)
+	t.Run("v match cf", subjson.Time(v).TimeEqual(expect))
+	// Output:
+	// === RUN   ParentTest/v_match_cf
+	// --- PASS: ParentTest/v_match_cf (0.00s)
+}
+
+func ExampleOnTime() {
+	const v = `"1985-12-19T18:15:00.0+01:00"`
+	cf := subtest.TimeEqual(time.Date(1985, 12, 19, 17, 15, 0, 0, time.UTC))
+
+	t.Run("v match cf", subtest.Value(v).Test(
+		subjson.OnTime(cf),
 	))
 	// Output:
 	// === RUN   ParentTest/v_match_cf

--- a/subjson/value.go
+++ b/subjson/value.go
@@ -2,18 +2,10 @@ package subjson
 
 import (
 	"encoding/json"
+	"time"
 
 	"github.com/searis/subtest"
 )
-
-// Interface returns a ValueFunc that decodes v into an interface{} value.
-func Interface(v interface{}) subtest.ValueFunc {
-	return func() (interface{}, error) {
-		var t interface{}
-		err := unmarshalJSON(v, &t)
-		return t, err
-	}
-}
 
 // String returns a ValueFunc that decodes v into an string value.
 func String(v interface{}) subtest.ValueFunc {
@@ -64,6 +56,24 @@ func Slice(v interface{}) subtest.ValueFunc {
 func Map(v interface{}) subtest.ValueFunc {
 	return func() (interface{}, error) {
 		var t map[string]json.RawMessage
+		err := unmarshalJSON(v, &t)
+		return t, err
+	}
+}
+
+// Time returns a ValueFunc that decodes v into a time.Time value.
+func Time(v interface{}) subtest.ValueFunc {
+	return func() (interface{}, error) {
+		var t time.Time
+		err := unmarshalJSON(v, &t)
+		return t, err
+	}
+}
+
+// Interface returns a ValueFunc that decodes v into an interface{} value.
+func Interface(v interface{}) subtest.ValueFunc {
+	return func() (interface{}, error) {
+		var t interface{}
 		err := unmarshalJSON(v, &t)
 		return t, err
 	}

--- a/value.go
+++ b/value.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strconv"
 	"testing"
+	"time"
 )
 
 // Test returns a test that fails fatally with the error f returned by f.
@@ -160,6 +161,26 @@ func (vf ValueFunc) NotNumericEqual(v float64) func(t *testing.T) {
 // NumericEqual is equivalent to vf.Test(NumericEqual(v)).
 func (vf ValueFunc) NumericEqual(v float64) func(t *testing.T) {
 	return vf.Test(NumericEqual(v))
+}
+
+// NotBefore is equivalent to vf.Test(NotBefore(v)).
+func (vf ValueFunc) NotBefore(v time.Time) func(t *testing.T) {
+	return vf.Test(NotBefore(v))
+}
+
+// Before is equivalent to vf.Test(Before(v)).
+func (vf ValueFunc) Before(v time.Time) func(t *testing.T) {
+	return vf.Test(Before(v))
+}
+
+// NotTimeEqual is equivalent to vf.Test(NotTimeEqual(v)).
+func (vf ValueFunc) NotTimeEqual(v time.Time) func(t *testing.T) {
+	return vf.Test(NotTimeEqual(v))
+}
+
+// TimeEqual is equivalent to vf.Test(TimeEqual(v)).
+func (vf ValueFunc) TimeEqual(v time.Time) func(t *testing.T) {
+	return vf.Test(TimeEqual(v))
 }
 
 // NotDeepEqual is equivalent to vf.Test(NotDeepEqual(v)).

--- a/value.go
+++ b/value.go
@@ -213,11 +213,6 @@ func (vf ValueFunc) ErrorIs(target error) func(t *testing.T) {
 	return vf.Test(ErrorIs(target))
 }
 
-// TestField is equivalent to vf.Test(Schema{Fields: fields}).
-func (vf ValueFunc) TestField(fields Fields) func(t *testing.T) {
-	return vf.Test(Schema{Fields: fields})
-}
-
 // ContainsMatch is equivalent to vf.Test(ContainsMatch{c}).
 func (vf ValueFunc) ContainsMatch(c Check) func(t *testing.T) {
 	return vf.Test(ContainsMatch(c))


### PR DESCRIPTION
commit fa4fb9701a6c040418dbd5d7d17d2341aac5f0a3 (HEAD -> back2thefuture)
Author: Sindre Myren <sindre@searis.no>
Date:   Fri Feb 28 01:07:38 2020 +0100

    Add time related checks and middleware

commit 3a0cbd442fc180603261fea2758181d66fc1fca7
Author: Sindre Myren <sindre@searis.no>
Date:   Fri Feb 28 01:06:54 2020 +0100

    Remove ValueFunc TestField shortcut

    After some experimentation, this shortcut feels less useful.

commit 398287405af9a8c47079dea7eb578c0d22233872
Author: Sindre Myren <sindre@searis.no>
Date:   Fri Feb 28 01:35:32 2020 +0100

    Run gofmt -s -w on schema_test.go